### PR TITLE
Fix for proper group

### DIFF
--- a/nova/files/juno/libvirtd.conf.Debian
+++ b/nova/files/juno/libvirtd.conf.Debian
@@ -84,7 +84,7 @@ auth_tcp = "none"
 # without becoming root.
 #
 # This is restricted to 'root' by default.
-unix_sock_group = "libvirtd"
+unix_sock_group = "libvirt"
 
 # Set the UNIX socket permissions for the R/O socket. This is used
 # for monitoring VM status only

--- a/nova/files/kilo/libvirtd.conf.Debian
+++ b/nova/files/kilo/libvirtd.conf.Debian
@@ -84,7 +84,7 @@ auth_tcp = "none"
 # without becoming root.
 #
 # This is restricted to 'root' by default.
-unix_sock_group = "libvirtd"
+unix_sock_group = "libvirt"
 
 # Set the UNIX socket permissions for the R/O socket. This is used
 # for monitoring VM status only

--- a/nova/files/liberty/libvirtd.conf.Debian
+++ b/nova/files/liberty/libvirtd.conf.Debian
@@ -84,7 +84,7 @@ auth_tcp = "none"
 # without becoming root.
 #
 # This is restricted to 'root' by default.
-unix_sock_group = "libvirtd"
+unix_sock_group = "libvirt"
 
 # Set the UNIX socket permissions for the R/O socket. This is used
 # for monitoring VM status only

--- a/nova/files/mitaka/libvirtd.conf.Debian
+++ b/nova/files/mitaka/libvirtd.conf.Debian
@@ -84,7 +84,7 @@ auth_tcp = "none"
 # without becoming root.
 #
 # This is restricted to 'root' by default.
-unix_sock_group = "libvirtd"
+unix_sock_group = "libvirt"
 
 # Set the UNIX socket permissions for the R/O socket. This is used
 # for monitoring VM status only


### PR DESCRIPTION
On Ubuntu based system the UNIX group is libvirt not libvirtd
Without this fix, nova instances can not be started properly
